### PR TITLE
Validate backup content before overwriting config file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,10 @@ There is no build step, package manager, or dependency beyond standard Unix util
 - Output XML files are named `{hostname}.xml`.
 
 ### Error Handling
-- Comment on line 17 of `cURLpfbkup.sh` flags a known gap: failed login is not explicitly detected. Any fix should check whether `csrf2` is empty before proceeding.
-- Unknown pfSense versions cause the script to `exit` without saving a file; this is intentional to avoid saving garbage HTML as XML.
+- Failed login is detected by checking whether `csrf2` is empty after the login POST; an empty token means the credentials were rejected, so the script prints an error and exits `1` without writing a backup.
+- The download response is written to `{hostname}.xml.tmp` and validated for the `<pfsense>` root element before being moved into place. A non-config (HTML) response leaves any existing `{hostname}.xml` untouched and exits `1`.
+- Unknown pfSense versions cause the script to `exit 1` without saving a file; this is intentional to avoid saving garbage HTML as XML.
+- All failure paths clean up the per-host cookie file and return a non-zero exit code.
 
 ## Security Considerations
 

--- a/cURLpfbkup.sh
+++ b/cURLpfbkup.sh
@@ -14,7 +14,12 @@ crlf=$'\r\n' #creates variable representing Windows (CR LF) required for line te
 #Get the 2nd CSRF Magic Token
 csrf2=$(curl -s -S --location --insecure --cookie cookies/${host}cookie.txt --cookie-jar cookies/${host}cookie.txt --data "login=Login&usernamefld=$user&passwordfld=$pass&__csrf_magic=$csrf" https://${host}/diag_backup.php | grep "name='__csrf_magic'" | sed 's/.*value="\(.*\)".*/\1/;q')
 
-#Attention: Need to write a check here for failed login.
+#Check for failed login: a successful login returns a 2nd CSRF token. An empty token means the credentials were rejected.
+if [ -z "$csrf2" ]; then
+	echo "Login failed for ${host} - check credentials" >&2
+	rm -f cookies/${host}cookie.txt
+	exit 1
+fi
 
 #After logging in, Get the pfSense version
 pfver=$(curl -s -S --location --insecure --cookie cookies/${host}cookie.txt --cookie-jar cookies/${host}cookie.txt https://${host}/index.php | grep -P '<strong>\d\.\d\.\d.*<\/strong>' | grep -Po '\d\.\d\.\d')
@@ -35,18 +40,31 @@ if [ "$pfmaver" == 2 ]; then
 		buttonaction='download'
 	else
 		echo 'Unknown Minor Version'
-		exit
+		rm -f cookies/${host}cookie.txt
+		exit 1
 	fi
 else
 	echo 'Unknown Major Version'
-	exit
+	rm -f cookies/${host}cookie.txt
+	exit 1
 fi
 
 #Building the MIME Multipart Media Encapsulation file
 poststring="-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"__csrf_magic\"${crlf}${crlf}$csrf2${crlf}-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"backuparea\"${crlf}${crlf}${crlf}-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"donotbackuprrd\"${crlf}${crlf}yes${crlf}-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"encrypt_password\"${crlf}${crlf}${crlf}-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"${buttonaction}\"${crlf}${crlf}Download configuration as XML${crlf}-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"restorearea\"${crlf}${crlf}${crlf}-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"conffile\"; filename=\"\"${crlf}Content-Type: application/octet-stream${crlf}${crlf}${crlf}-----------------------------7e12e22ee971f00${crlf}Content-Disposition: form-data; name=\"decrypt_password\"${crlf}${crlf}${crlf}-----------------------------7e12e22ee971f00--${crlf}"
 
-#Post file to initiate XML backup
-curl -s -S --location --insecure --cookie cookies/${host}cookie.txt --cookie-jar cookies/${host}cookie.txt -H "Content-Type: multipart/form-data; boundary=---------------------------7e12e22ee971f00"  -d "$poststring" https://${host}/diag_backup.php > ${host}.xml
+#Post file to initiate XML backup. Write to a temp file first so a failed download cannot clobber a good backup.
+curl -s -S --location --insecure --cookie cookies/${host}cookie.txt --cookie-jar cookies/${host}cookie.txt -H "Content-Type: multipart/form-data; boundary=---------------------------7e12e22ee971f00"  -d "$poststring" https://${host}/diag_backup.php > ${host}.xml.tmp
+
+#Validate the response is a real pfSense config before overwriting. A login/error page is HTML and never contains the <pfsense> root element.
+if grep -q '<pfsense>' ${host}.xml.tmp; then
+	mv ${host}.xml.tmp ${host}.xml
+	echo "Backup saved to ${host}.xml"
+else
+	echo "Backup for ${host} did not return valid config - existing backup left untouched" >&2
+	rm -f ${host}.xml.tmp
+	rm -f cookies/${host}cookie.txt
+	exit 1
+fi
 
 #Deleting cookie after completion
-rm cookies/${host}cookie.txt
+rm -f cookies/${host}cookie.txt


### PR DESCRIPTION
Fixes #1. Previously a failed run (bad login, error page, or any
non-XML response) would clobber a good {hostname}.xml with the HTML
response. Now:

- Detect failed login by checking the 2nd CSRF token is non-empty
- Download to a temp file, validate it contains the <pfsense> root
  element, and only then atomically move it into place; otherwise the
  existing backup is left untouched
- Clean up the per-host cookie and return non-zero on all failure paths

https://claude.ai/code/session_01Qs95D6bvYAo74cFpsfsHgJ